### PR TITLE
Show failing test tab when there are failing tests

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -600,7 +600,7 @@ struct HTMLTemplates
     </style>
   </head>
 
-  <body>
+  <body onload=\"setInitialState();\">
     <div id=\"content\">
       <header>
         <div id=\"title\">
@@ -1076,6 +1076,18 @@ struct HTMLTemplates
   """
 
   static let run = """
+  <script type=\"text/javascript\">
+    function setInitialState() {
+      var numberOfFailedTests = [[N_OF_FAILED_TESTS]];
+
+      if (numberOfFailedTests <= 0) {
+        return;
+      }
+
+      var element = document.getElementById(\"failed-tests-toolbar-option\");
+      showFailedScenariosOnly(element);
+    }
+  </script>
   <div class=\"run\" id=\"device_[[DEVICE_IDENTIFIER]]\">
     <div class=\"tests\">
       <div class=\"tests-header\">
@@ -1083,7 +1095,7 @@ struct HTMLTemplates
           <li onclick=\"showAllScenarios(this);\" class=\"selected\">All ([[N_OF_TESTS]])</li>
           <li onclick=\"showSuccessfulScenariosOnly(this);\">Passed ([[N_OF_PASSED_TESTS]])</li>
           <li onclick=\"showSkippedScenariosOnly(this);\">Skipped ([[N_OF_SKIPPED_TESTS]])</li>
-          <li onclick=\"showFailedScenariosOnly(this);\">Failed ([[N_OF_FAILED_TESTS]])</li>
+          <li id=\"failed-tests-toolbar-option\" onclick=\"showFailedScenariosOnly(this);\">Failed ([[N_OF_FAILED_TESTS]])</li>
           <li onclick=\"showMixedScenariosOnly(this);\">Mixed ([[N_OF_MIXED_TESTS]])</li>
         </ul>
         <ul class=\"toolbar table-header\">

--- a/Sources/XCTestHTMLReportCore/HTML/index.html
+++ b/Sources/XCTestHTMLReportCore/HTML/index.html
@@ -551,7 +551,7 @@
     </style>
   </head>
 
-  <body>
+  <body onload="setInitialState();">
     <div id="content">
       <header>
         <div id="title">

--- a/Sources/XCTestHTMLReportCore/HTML/run.html
+++ b/Sources/XCTestHTMLReportCore/HTML/run.html
@@ -1,11 +1,23 @@
-  <div class="run" id="device_[[DEVICE_IDENTIFIER]]">
+<script type="text/javascript">
+  function setInitialState() {
+    var numberOfFailedTests = [[N_OF_FAILED_TESTS]];
+
+    if (numberOfFailedTests <= 0) {
+      return;
+    }
+
+    var element = document.getElementById("failed-tests-toolbar-option");
+    showFailedScenariosOnly(element);
+  }
+</script>
+<div class="run" id="device_[[DEVICE_IDENTIFIER]]">
     <div class="tests">
       <div class="tests-header">
         <ul class="toolbar toggle-toolbar">
           <li onclick="showAllScenarios(this);" class="selected">All ([[N_OF_TESTS]])</li>
           <li onclick="showSuccessfulScenariosOnly(this);">Passed ([[N_OF_PASSED_TESTS]])</li>
           <li onclick="showSkippedScenariosOnly(this);">Skipped ([[N_OF_SKIPPED_TESTS]])</li>
-          <li onclick="showFailedScenariosOnly(this);">Failed ([[N_OF_FAILED_TESTS]])</li>
+          <li id="failed-tests-toolbar-option" onclick="showFailedScenariosOnly(this);">Failed ([[N_OF_FAILED_TESTS]])</li>
           <li onclick=\"showMixedScenariosOnly(this);\">Mixed ([[N_OF_MIXED_TESTS]])</li>
         </ul>
         <ul class="toolbar table-header">


### PR DESCRIPTION
What this does is that it determines if the failing tests tab should be shown once the body loads. The number if failing test will be injected into the `setInitialState` function and if it is zero then all tests but if it is more then the failing tests will be shown. 